### PR TITLE
Correctifs concernant l'identité du répondant et du créateur des enquêtes ainsi que la cohérence pole-organisation

### DIFF
--- a/backend/responses/serializers/response.py
+++ b/backend/responses/serializers/response.py
@@ -11,12 +11,12 @@ class ResponseSerializer(serializers.ModelSerializer):
         fields = (
             "id",
             "survey",
-            "respondant",  # TODO : devrait être peuplé automatiquement
+            "respondant",
             "data",
             "context",
             "status",
         )
-        read_only_fields = ("id", "status")
+        read_only_fields = ("id", "status", "respondant")
 
 
 class ResponseDisplaySerializer(serializers.ModelSerializer):

--- a/backend/responses/tests/test_create_response.py
+++ b/backend/responses/tests/test_create_response.py
@@ -6,12 +6,12 @@ from organisations.models import MembershipType
 from rest_framework import status
 from rest_framework.test import APITestCase
 from surveys.factories import SurveyFactory
+from users.factories import UserFactory
 
 
-def response_payload(survey, user):
+def response_payload(survey):
     return {
         "survey": survey.id,
-        "respondant": user.id,
         "data": {},
     }
 
@@ -37,7 +37,7 @@ class TestCreateResponse(APITestCase):
         survey = SurveyFactory()
         response = self.client.post(
             reverse("response_list_create"),
-            response_payload(survey, authenticate.user),
+            response_payload(survey),
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -53,7 +53,7 @@ class TestCreateResponse(APITestCase):
         )
         response = self.client.post(
             reverse("response_list_create"),
-            response_payload(survey, authenticate.user),
+            response_payload(survey),
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -69,7 +69,7 @@ class TestCreateResponse(APITestCase):
         )
         response = self.client.post(
             reverse("response_list_create"),
-            response_payload(survey, authenticate.user),
+            response_payload(survey),
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -85,7 +85,7 @@ class TestCreateResponse(APITestCase):
         )
         response = self.client.post(
             reverse("response_list_create"),
-            response_payload(survey, authenticate.user),
+            response_payload(survey),
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -101,7 +101,7 @@ class TestCreateResponse(APITestCase):
         MembershipFactory(user=authenticate.user, organisation=org, membership_type=MembershipType.RESPONDER)
         response = self.client.post(
             reverse("response_list_create"),
-            response_payload(survey, authenticate.user),
+            response_payload(survey),
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -116,7 +116,7 @@ class TestCreateResponse(APITestCase):
         other_survey = SurveyFactory()
         response = self.client.post(
             reverse("response_list_create"),
-            response_payload(other_survey, authenticate.user),
+            response_payload(other_survey),
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -134,7 +134,7 @@ class TestCreateResponse(APITestCase):
         )
         response = self.client.post(
             reverse("response_list_create"),
-            response_payload(survey, authenticate.user),
+            response_payload(survey),
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -152,7 +152,7 @@ class TestCreateResponse(APITestCase):
         )
         response = self.client.post(
             reverse("response_list_create"),
-            response_payload(survey, authenticate.user),
+            response_payload(survey),
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -171,7 +171,44 @@ class TestCreateResponse(APITestCase):
         )
         response = self.client.post(
             reverse("response_list_create"),
-            response_payload(survey, authenticate.user),
+            response_payload(survey),
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_respondant_is_set_to_authenticated_user(self):
+        """
+        Le champ respondant est automatiquement renseigné avec l'utilisateur authentifié
+        """
+        survey = SurveyFactory()
+        MembershipFactory(
+            user=authenticate.user, organisation=survey.organisation, membership_type=MembershipType.RESPONDER
+        )
+        response = self.client.post(
+            reverse("response_list_create"),
+            response_payload(survey),
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["respondant"], authenticate.user.id)
+
+    @authenticate
+    def test_respondant_ignores_frontend_value(self):
+        """
+        Une valeur de respondant fournie par le frontend est ignorée
+        """
+        survey = SurveyFactory()
+        other_user = UserFactory()
+        MembershipFactory(
+            user=authenticate.user, organisation=survey.organisation, membership_type=MembershipType.RESPONDER
+        )
+        payload = response_payload(survey)
+        payload["respondant"] = other_user.id
+        response = self.client.post(
+            reverse("response_list_create"),
+            payload,
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["respondant"], authenticate.user.id)

--- a/backend/responses/views/response.py
+++ b/backend/responses/views/response.py
@@ -40,6 +40,9 @@ class ResponseListCreateAPIView(ResponseQuerySetMixin, ListCreateAPIView):
             return [IsAuthenticated(), CanCreateResponse()]
         return [IsAuthenticated()]
 
+    def perform_create(self, serializer):
+        serializer.save(respondant=self.request.user)
+
 
 class ResponseRetrieveAPIView(ResponseQuerySetMixin, RetrieveAPIView):
     serializer_class = FullResponseSerializer

--- a/backend/surveys/models/survey.py
+++ b/backend/surveys/models/survey.py
@@ -42,3 +42,6 @@ class Survey(TimeStampable, Deactivable, Historisable):
         if self.campaign:
             if self.organisation != self.campaign.organisation or self.pole != self.campaign.pole:
                 raise ValidationError("La campagne doit appartenir à la même organisation/pôle que l'enquête.")
+        if self.pole and self.organisation:
+            if self.pole != self.organisation:
+                raise ValidationError("Le pôle doit appartenir à l'organisation de l'enquête.")

--- a/backend/surveys/permissions.py
+++ b/backend/surveys/permissions.py
@@ -1,4 +1,6 @@
-from organisations.models import Membership, MembershipType
+from django.core.exceptions import ObjectDoesNotExist
+
+from organisations.models import Membership, MembershipType, Organisation, Pole
 from rest_framework import permissions
 
 
@@ -9,6 +11,18 @@ class CanCreateSurvey(permissions.BasePermission):
     def has_permission(self, request, view):
         organisation_id = request.data.get("organisation")
         pole_id = request.data.get("pole")
+
+        if not organisation_id:
+            return False
+
+        if pole_id:
+            try:
+                pole = Pole.objects.get(pk=pole_id)
+                organisation = Organisation.objects.get(pk=organisation_id)
+                if pole.organisation != organisation:
+                    return False
+            except ObjectDoesNotExist as _:
+                return False
 
         qs = Membership.objects.filter(
             user=request.user,

--- a/backend/surveys/serializers/survey.py
+++ b/backend/surveys/serializers/survey.py
@@ -33,9 +33,9 @@ class SurveySerializer(serializers.ModelSerializer):
             "json_schema",
             "survey_type",
             "campaign",
-            "created_by",  # TODO : ça devrait être peuplé automatiquement
+            "created_by",
         )
-        read_only_fields = ("id",)
+        read_only_fields = ("id", "created_by")
 
 
 class FullSurveySerializer(serializers.ModelSerializer):

--- a/backend/surveys/tests/test_create_survey.py
+++ b/backend/surveys/tests/test_create_survey.py
@@ -117,6 +117,22 @@ class TestCreateSurvey(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
+    def test_org_admin_cannot_create_survey_for_other_org_pole(self):
+        """
+        Un ADMIN d'organisation ne peut pas créer une enquête pour un pole d'une autre organisation
+        """
+        org = OrganisationFactory()
+        other_org = OrganisationFactory()
+        pole = PoleFactory(organisation=other_org)
+        MembershipFactory(user=authenticate.user, organisation=org, membership_type=MembershipType.ADMIN)
+        response = self.client.post(
+            reverse("survey_list_create"),
+            survey_payload(org, authenticate.user, pole=pole),
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
     def test_pole_admin_can_create_survey_for_their_pole(self):
         """
         Un ADMIN de pôle peut créer une enquête pour son pôle

--- a/backend/surveys/tests/test_create_survey.py
+++ b/backend/surveys/tests/test_create_survey.py
@@ -5,13 +5,13 @@ from organisations.factories import MembershipFactory, OrganisationFactory, Pole
 from organisations.models import MembershipType
 from rest_framework import status
 from rest_framework.test import APITestCase
+from users.factories import UserFactory
 
 
-def survey_payload(organisation, user, pole=None):
+def survey_payload(organisation, pole=None):
     payload = {
         "title": "Enquête test",
         "organisation": organisation.id,
-        "created_by": user.id,
     }
     if pole:
         payload["pole"] = pole.id
@@ -39,7 +39,7 @@ class TestCreateSurvey(APITestCase):
         org = OrganisationFactory()
         response = self.client.post(
             reverse("survey_list_create"),
-            survey_payload(org, authenticate.user),
+            survey_payload(org),
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -53,7 +53,7 @@ class TestCreateSurvey(APITestCase):
         MembershipFactory(user=authenticate.user, organisation=org, membership_type=MembershipType.RESPONDER)
         response = self.client.post(
             reverse("survey_list_create"),
-            survey_payload(org, authenticate.user),
+            survey_payload(org),
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -67,7 +67,7 @@ class TestCreateSurvey(APITestCase):
         MembershipFactory(user=authenticate.user, organisation=org, membership_type=MembershipType.MANAGER)
         response = self.client.post(
             reverse("survey_list_create"),
-            survey_payload(org, authenticate.user),
+            survey_payload(org),
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -81,7 +81,7 @@ class TestCreateSurvey(APITestCase):
         MembershipFactory(user=authenticate.user, organisation=org, membership_type=MembershipType.ADMIN)
         response = self.client.post(
             reverse("survey_list_create"),
-            survey_payload(org, authenticate.user),
+            survey_payload(org),
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -96,7 +96,7 @@ class TestCreateSurvey(APITestCase):
         MembershipFactory(user=authenticate.user, organisation=org, membership_type=MembershipType.ADMIN)
         response = self.client.post(
             reverse("survey_list_create"),
-            survey_payload(org, authenticate.user, pole=pole),
+            survey_payload(org, pole=pole),
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -111,7 +111,7 @@ class TestCreateSurvey(APITestCase):
         MembershipFactory(user=authenticate.user, organisation=org, membership_type=MembershipType.ADMIN)
         response = self.client.post(
             reverse("survey_list_create"),
-            survey_payload(other_org, authenticate.user),
+            survey_payload(other_org),
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -127,7 +127,7 @@ class TestCreateSurvey(APITestCase):
         MembershipFactory(user=authenticate.user, organisation=org, membership_type=MembershipType.ADMIN)
         response = self.client.post(
             reverse("survey_list_create"),
-            survey_payload(org, authenticate.user, pole=pole),
+            survey_payload(org, pole=pole),
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -142,7 +142,7 @@ class TestCreateSurvey(APITestCase):
         MembershipFactory(user=authenticate.user, organisation=org, pole=pole, membership_type=MembershipType.ADMIN)
         response = self.client.post(
             reverse("survey_list_create"),
-            survey_payload(org, authenticate.user, pole=pole),
+            survey_payload(org, pole=pole),
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -157,7 +157,7 @@ class TestCreateSurvey(APITestCase):
         MembershipFactory(user=authenticate.user, organisation=org, pole=pole, membership_type=MembershipType.ADMIN)
         response = self.client.post(
             reverse("survey_list_create"),
-            survey_payload(org, authenticate.user),
+            survey_payload(org),
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -173,7 +173,40 @@ class TestCreateSurvey(APITestCase):
         MembershipFactory(user=authenticate.user, organisation=org, pole=pole, membership_type=MembershipType.ADMIN)
         response = self.client.post(
             reverse("survey_list_create"),
-            survey_payload(org, authenticate.user, pole=other_pole),
+            survey_payload(org, pole=other_pole),
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_created_by_is_set_to_authenticated_user(self):
+        """
+        Le champ created_by est automatiquement renseigné avec l'utilisateur authentifié
+        """
+        org = OrganisationFactory()
+        MembershipFactory(user=authenticate.user, organisation=org, membership_type=MembershipType.ADMIN)
+        response = self.client.post(
+            reverse("survey_list_create"),
+            survey_payload(org),
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["created_by"], authenticate.user.id)
+
+    @authenticate
+    def test_created_by_ignores_frontend_value(self):
+        """
+        Une valeur de created_by fournie par le frontend est ignorée
+        """
+        org = OrganisationFactory()
+        other_user = UserFactory()
+        MembershipFactory(user=authenticate.user, organisation=org, membership_type=MembershipType.ADMIN)
+        payload = survey_payload(org)
+        payload["created_by"] = other_user.id
+        response = self.client.post(
+            reverse("survey_list_create"),
+            payload,
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["created_by"], authenticate.user.id)

--- a/backend/surveys/views/survey.py
+++ b/backend/surveys/views/survey.py
@@ -30,6 +30,9 @@ class SurveyListCreateAPIView(SurveyQuerySetMixin, ListCreateAPIView):
             return [IsAuthenticated(), CanCreateSurvey()]
         return [IsAuthenticated()]
 
+    def perform_create(self, serializer):
+        serializer.save(created_by=self.request.user)
+
 
 class SurveyResponderListAPIView(ListAPIView):
     """


### PR DESCRIPTION
Ces correctifs concernent deux sujets : 
- transmission de la responsabilité de l'assignation du répondant et créateur au backend, rendant ainsi impossible une usurpation d'identité. 
- vérification de la cohérence pole-organisation lors de la création d'une enquête, prévenant la rupture d'intégrité du modèles organisation/pôle 

