### PR TITLE
Validation front-end des champs basiques

### DIFF
--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "fr.gouv.beta.sylvasan"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 14
-        versionName "0.0.14"
+        versionCode 15
+        versionName "0.0.15"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/mobile/src/components/SurveySummary.vue
+++ b/mobile/src/components/SurveySummary.vue
@@ -5,6 +5,7 @@ import type { Survey, SurveyField, ImageItem } from "@shared-types/survey"
 import ResponseBadge from "./ResponseBadge.vue"
 import { formatDate } from "../composables/offlineMapMetadata"
 import { resolveFieldValue } from "@shared-utils/survey"
+import { validateResponse } from "@shared-utils/validateField"
 import { useVocabulariesStore } from "../stores/vocabularies"
 import ImageViewer from "@shared-components/ImageViewer.vue"
 
@@ -45,6 +46,11 @@ const imageSrc = (item: ImageItem): string | null => {
   return null
 }
 
+// Only validate when showing the pre-submission summary, not for already-submitted responses
+const validationErrors = computed(() =>
+  response ? {} : validateResponse(survey.jsonSchema.fields, resolvedData.value)
+)
+
 const viewerOpen = ref(false)
 const viewerImages = ref<ImageItem[]>([])
 const viewerIndex = ref(0)
@@ -72,26 +78,26 @@ const openViewer = (images: ImageItem[], index: number) => {
     </div>
 
     <div class="p-4">
-      <div v-for="entry in Object.entries(resolvedData)" :key="entry[0]">
+      <div v-for="field in survey.jsonSchema.fields" :key="field.id">
         <p class="fr-text--sm font-bold text-stone-500 mb-0!">
-          {{ fieldLabel(entry[0]) }}
+          {{ field.label }}
         </p>
 
         <!-- Array field -->
-        <template v-if="isArrayField(entry[0]) && Array.isArray(entry[1])">
-          <p v-if="!entry[1].length" class="italic mb-0! text-stone-500">
+        <template v-if="isArrayField(field.id) && Array.isArray(resolvedData[field.id])">
+          <p v-if="!(resolvedData[field.id] as unknown[]).length" class="italic mb-0! text-stone-500">
             Non renseigné
           </p>
           <p v-else class="font-medium mb-2! text-stone-500">
-            {{ entry[1].length }} entrée(s) :
+            {{ (resolvedData[field.id] as unknown[]).length }} entrée(s) :
           </p>
           <div
-            v-for="(item, idx) in (entry[1] as Record<string, unknown>[])"
-            :key="`${entry[0]}-${idx}`"
+            v-for="(item, idx) in (resolvedData[field.id] as Record<string, unknown>[])"
+            :key="`${field.id}-${idx}`"
             class="border border-slate-200 rounded p-3 mb-2 bg-slate-50"
           >
             <div
-              v-for="subField in getSubFields(entry[0])"
+              v-for="subField in getSubFields(field.id)"
               :key="subField.id"
               class="flex gap-4"
             >
@@ -100,13 +106,9 @@ const openViewer = (images: ImageItem[], index: number) => {
               </p>
               <p
                 class="font-medium mb-0!"
-                v-if="
-                  resolveFieldValue(subField, item[subField.id], vocabularySets)
-                "
+                v-if="resolveFieldValue(subField, item[subField.id], vocabularySets)"
               >
-                {{
-                  resolveFieldValue(subField, item[subField.id], vocabularySets)
-                }}
+                {{ resolveFieldValue(subField, item[subField.id], vocabularySets) }}
               </p>
               <p class="italic mb-0! text-stone-500" v-else>Non renseigné</p>
             </div>
@@ -114,16 +116,16 @@ const openViewer = (images: ImageItem[], index: number) => {
         </template>
 
         <!-- Champ images -->
-        <template v-else-if="isImageField(entry[0]) && Array.isArray(entry[1])">
-          <p v-if="!entry[1].length" class="italic mb-0! text-stone-500">
+        <template v-else-if="isImageField(field.id) && Array.isArray(resolvedData[field.id])">
+          <p v-if="!(resolvedData[field.id] as unknown[]).length" class="italic mb-0! text-stone-500">
             Non renseigné
           </p>
           <div v-else class="grid grid-cols-4 gap-2 my-2">
             <div
-              v-for="(img, idx) in (entry[1] as ImageItem[])"
+              v-for="(img, idx) in (resolvedData[field.id] as ImageItem[])"
               :key="idx"
               class="aspect-square rounded overflow-hidden border border-slate-200 cursor-pointer"
-              @click="openViewer(entry[1] as ImageItem[], idx)"
+              @click="openViewer(resolvedData[field.id] as ImageItem[], idx)"
             >
               <img
                 v-if="imageSrc(img)"
@@ -143,11 +145,15 @@ const openViewer = (images: ImageItem[], index: number) => {
 
         <!-- All other fields -->
         <template v-else>
-          <p class="font-medium mb-0!" v-if="resolveValue(entry[0], entry[1])">
-            {{ resolveValue(entry[0], entry[1]) }}
+          <p class="font-medium mb-0!" v-if="resolveValue(field.id, resolvedData[field.id])">
+            {{ resolveValue(field.id, resolvedData[field.id]) }}
           </p>
           <p class="italic mb-0! text-stone-500" v-else>Non renseigné</p>
         </template>
+
+        <p v-if="validationErrors[field.id]" class="fr-error-text fr-text--sm mt-1! mb-0!">
+          {{ validationErrors[field.id] }}
+        </p>
 
         <hr class="p-1! mt-2!" />
       </div>

--- a/mobile/src/components/SurveySummary.vue
+++ b/mobile/src/components/SurveySummary.vue
@@ -40,13 +40,14 @@ const getSubFields = (fieldId: string): SurveyField[] =>
   survey.jsonSchema.fields.find((f) => f.id === fieldId)?.fields ?? []
 
 const imageSrc = (item: ImageItem): string | null => {
-  if ("type" in item) return (window as any).Capacitor?.convertFileSrc(item.path) ?? null
+  if ("type" in item)
+    return (window as any).Capacitor?.convertFileSrc(item.path) ?? null
   if ("file" in item) return `data:image/jpeg;base64,${item.file}`
   if (item.thumbnail) return `data:image/jpeg;base64,${item.thumbnail}`
   return null
 }
 
-// Only validate when showing the pre-submission summary, not for already-submitted responses
+// On montre la validation seulement lors que la réponse n'est pas sauvegardé dans le backend
 const validationErrors = computed(() =>
   response ? {} : validateResponse(survey.jsonSchema.fields, resolvedData.value)
 )
@@ -84,8 +85,13 @@ const openViewer = (images: ImageItem[], index: number) => {
         </p>
 
         <!-- Array field -->
-        <template v-if="isArrayField(field.id) && Array.isArray(resolvedData[field.id])">
-          <p v-if="!(resolvedData[field.id] as unknown[]).length" class="italic mb-0! text-stone-500">
+        <template
+          v-if="isArrayField(field.id) && Array.isArray(resolvedData[field.id])"
+        >
+          <p
+            v-if="!(resolvedData[field.id] as unknown[]).length"
+            class="italic mb-0! text-stone-500"
+          >
             Non renseigné
           </p>
           <p v-else class="font-medium mb-2! text-stone-500">
@@ -106,9 +112,13 @@ const openViewer = (images: ImageItem[], index: number) => {
               </p>
               <p
                 class="font-medium mb-0!"
-                v-if="resolveFieldValue(subField, item[subField.id], vocabularySets)"
+                v-if="
+                  resolveFieldValue(subField, item[subField.id], vocabularySets)
+                "
               >
-                {{ resolveFieldValue(subField, item[subField.id], vocabularySets) }}
+                {{
+                  resolveFieldValue(subField, item[subField.id], vocabularySets)
+                }}
               </p>
               <p class="italic mb-0! text-stone-500" v-else>Non renseigné</p>
             </div>
@@ -116,8 +126,15 @@ const openViewer = (images: ImageItem[], index: number) => {
         </template>
 
         <!-- Champ images -->
-        <template v-else-if="isImageField(field.id) && Array.isArray(resolvedData[field.id])">
-          <p v-if="!(resolvedData[field.id] as unknown[]).length" class="italic mb-0! text-stone-500">
+        <template
+          v-else-if="
+            isImageField(field.id) && Array.isArray(resolvedData[field.id])
+          "
+        >
+          <p
+            v-if="!(resolvedData[field.id] as unknown[]).length"
+            class="italic mb-0! text-stone-500"
+          >
             Non renseigné
           </p>
           <div v-else class="grid grid-cols-4 gap-2 my-2">
@@ -145,13 +162,19 @@ const openViewer = (images: ImageItem[], index: number) => {
 
         <!-- All other fields -->
         <template v-else>
-          <p class="font-medium mb-0!" v-if="resolveValue(field.id, resolvedData[field.id])">
+          <p
+            class="font-medium mb-0!"
+            v-if="resolveValue(field.id, resolvedData[field.id])"
+          >
             {{ resolveValue(field.id, resolvedData[field.id]) }}
           </p>
           <p class="italic mb-0! text-stone-500" v-else>Non renseigné</p>
         </template>
 
-        <p v-if="validationErrors[field.id]" class="fr-error-text fr-text--sm mt-1! mb-0!">
+        <p
+          v-if="validationErrors[field.id]"
+          class="fr-error-text fr-text--sm mt-1! mb-0!"
+        >
           {{ validationErrors[field.id] }}
         </p>
 

--- a/mobile/src/components/SurveySummary.vue
+++ b/mobile/src/components/SurveySummary.vue
@@ -22,9 +22,6 @@ const isRemote = (res: LocalResponse | ResponseFull): res is ResponseFull =>
 
 const resolvedData = computed(() => response?.data ?? data ?? {})
 
-const fieldLabel = (fieldId: string): string =>
-  survey.jsonSchema.fields.find((f) => f.id === fieldId)?.label ?? fieldId
-
 const resolveValue = (fieldId: string, raw: unknown): string => {
   const field = survey.jsonSchema.fields.find((f) => f.id === fieldId)
   return resolveFieldValue(field, raw, vocabularySets)

--- a/mobile/src/components/SurveySummary.vue
+++ b/mobile/src/components/SurveySummary.vue
@@ -5,7 +5,7 @@ import type { Survey, SurveyField, ImageItem } from "@shared-types/survey"
 import ResponseBadge from "./ResponseBadge.vue"
 import { formatDate } from "../composables/offlineMapMetadata"
 import { resolveFieldValue } from "@shared-utils/survey"
-import { validateResponse } from "@shared-utils/validateField"
+import { validateResponse, validateField } from "@shared-utils/validateField"
 import { useVocabulariesStore } from "../stores/vocabularies"
 import ImageViewer from "@shared-components/ImageViewer.vue"
 
@@ -48,6 +48,14 @@ const imageSrc = (item: ImageItem): string | null => {
 const validationErrors = computed(() =>
   response ? {} : validateResponse(survey.jsonSchema.fields, resolvedData.value)
 )
+
+const getSubFieldError = (
+  subField: SurveyField,
+  value: unknown
+): string | null => {
+  if (response) return null
+  return validateField(subField, value ?? null)
+}
 
 const viewerOpen = ref(false)
 const viewerImages = ref<ImageItem[]>([])
@@ -99,25 +107,37 @@ const openViewer = (images: ImageItem[], index: number) => {
             :key="`${field.id}-${idx}`"
             class="border border-slate-200 rounded p-3 mb-2 bg-slate-50"
           >
-            <div
-              v-for="subField in getSubFields(field.id)"
-              :key="subField.id"
-              class="flex gap-4"
-            >
-              <p class="fr-text--sm text-stone-400 mb-0!">
-                {{ subField.label }}
-              </p>
+            <div v-for="subField in getSubFields(field.id)" :key="subField.id">
+              <div class="flex gap-4">
+                <p class="fr-text--sm text-stone-400 mb-0!">
+                  {{ subField.label }}
+                </p>
+                <p
+                  class="font-medium mb-0!"
+                  v-if="
+                    resolveFieldValue(
+                      subField,
+                      item[subField.id],
+                      vocabularySets
+                    )
+                  "
+                >
+                  {{
+                    resolveFieldValue(
+                      subField,
+                      item[subField.id],
+                      vocabularySets
+                    )
+                  }}
+                </p>
+                <p class="italic mb-0! text-stone-500" v-else>Non renseigné</p>
+              </div>
               <p
-                class="font-medium mb-0!"
-                v-if="
-                  resolveFieldValue(subField, item[subField.id], vocabularySets)
-                "
+                v-if="getSubFieldError(subField, item[subField.id])"
+                class="fr-error-text fr-text--sm mt-0! mb-2!"
               >
-                {{
-                  resolveFieldValue(subField, item[subField.id], vocabularySets)
-                }}
+                {{ getSubFieldError(subField, item[subField.id]) }}
               </p>
-              <p class="italic mb-0! text-stone-500" v-else>Non renseigné</p>
             </div>
           </div>
         </template>

--- a/mobile/src/pages/SurveyPage.vue
+++ b/mobile/src/pages/SurveyPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, onMounted } from "vue"
+import { computed, ref, watch, onMounted } from "vue"
 import { useRoute } from "vue-router"
 import { useSurveysStore } from "../stores/surveys"
 import { useToastStore } from "../stores/toast"
@@ -46,6 +46,12 @@ const dataReady = ref(false)
 const showSummary = ref(false)
 const summaryData = ref<Record<string, unknown>>({})
 const saving = ref(false)
+const forceValidate = ref(false)
+
+// Force validation immediately when a draft is opened (user already saw/filled the form)
+watch(prefillData, (val) => { if (val) forceValidate.value = true })
+// Force validation when going back from summary (user clicked "Modifier")
+watch(showSummary, (val, prev) => { if (!val && prev) forceValidate.value = true })
 
 const summaryHasErrors = computed(() => {
   const fields = survey.value?.jsonSchema?.fields ?? []
@@ -197,6 +203,7 @@ const saveResponse = async (data: Record<string, unknown>) => {
             :allowSubmit="true"
             :schema="survey.jsonSchema"
             :prefillData="prefillData"
+            :forceValidate="forceValidate"
             :vocabularies="vocabularySets"
             :mapComponent="MapField"
             @done="onSurveyDone"

--- a/mobile/src/pages/SurveyPage.vue
+++ b/mobile/src/pages/SurveyPage.vue
@@ -28,6 +28,7 @@ import { useResponsesStore } from "../stores/responses"
 import { storeToRefs } from "pinia"
 import { useVocabulariesStore } from "../stores/vocabularies"
 import { saveImagesToFilesystem } from "../utils/imageStorage"
+import { validateResponse } from "@shared-utils/validateField"
 
 const props = defineProps<{
   id?: number
@@ -45,6 +46,11 @@ const dataReady = ref(false)
 const showSummary = ref(false)
 const summaryData = ref<Record<string, unknown>>({})
 const saving = ref(false)
+
+const summaryHasErrors = computed(() => {
+  const fields = survey.value?.jsonSchema?.fields ?? []
+  return Object.keys(validateResponse(fields, summaryData.value)).length > 0
+})
 
 const router = useIonRouter()
 const route = useRoute()
@@ -215,7 +221,7 @@ const saveResponse = async (data: Record<string, unknown>) => {
               <DsfrButton
                 label="Sauvegarder"
                 icon="ri-cloud-line"
-                :disabled="saving"
+                :disabled="saving || summaryHasErrors"
                 @click="saveResponse(summaryData)"
               />
             </div>

--- a/mobile/src/utils/data-fetching.ts
+++ b/mobile/src/utils/data-fetching.ts
@@ -35,7 +35,8 @@ export const useApiFetch = createFetch({
     async onFetchError(ctx) {
       const authStore = useAuthStore()
       const { refresh } = storeToRefs(useAuthStore())
-      const shouldRetry = ctx.response?.status === 401 && refresh.value
+      const isRefreshEndpoint = ctx.context.url?.toString().includes("/token/refresh/")
+      const shouldRetry = ctx.response?.status === 401 && refresh.value && !isRefreshEndpoint
 
       if (shouldRetry) {
         const refreshSuccessful = await authStore.refreshToken()

--- a/mobile/tests/validation/validateField.test.ts
+++ b/mobile/tests/validation/validateField.test.ts
@@ -244,3 +244,53 @@ describe("validateResponse", () => {
     expect(errors).not.toHaveProperty("note")
   })
 })
+
+describe("validateResponse — sub-fields (array widget)", () => {
+  const arraySchema: SurveyField[] = [
+    field({
+      id: "observations",
+      type: "array",
+      ui: { widget: "array" },
+      fields: [
+        field({ id: "espece", type: "string", required: true }),
+        field({ id: "count", type: "number", ui: { widget: "number" }, validation: { min: 1 } }),
+      ],
+    }),
+  ]
+
+  it("returns no errors when all sub-fields are valid", () => {
+    const errors = validateResponse(arraySchema, {
+      observations: [{ espece: "Aigle", count: 3 }],
+    })
+    expect(errors).toEqual({})
+  })
+
+  it("reports a required sub-field error with composite key parentId.subFieldId", () => {
+    const errors = validateResponse(arraySchema, {
+      observations: [{ espece: "", count: 3 }],
+    })
+    expect(errors).toHaveProperty("observations.espece")
+  })
+
+  it("reports a constraint violation on a sub-field", () => {
+    const errors = validateResponse(arraySchema, {
+      observations: [{ espece: "Aigle", count: 0 }],
+    })
+    expect(errors).toHaveProperty("observations.count")
+  })
+
+  it("records only the first occurrence when multiple items fail the same sub-field", () => {
+    const errors = validateResponse(arraySchema, {
+      observations: [
+        { espece: "", count: 1 },
+        { espece: "", count: 1 },
+      ],
+    })
+    expect(Object.keys(errors).filter((k) => k === "observations.espece")).toHaveLength(1)
+  })
+
+  it("returns no sub-field errors when the array is empty", () => {
+    const errors = validateResponse(arraySchema, { observations: [] })
+    expect(errors).toEqual({})
+  })
+})

--- a/mobile/tests/validation/validateField.test.ts
+++ b/mobile/tests/validation/validateField.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect } from "vitest"
+import {
+  validateField,
+  validateResponse,
+} from "../../../shared/utils/validateField"
+import type { SurveyField } from "../../../shared/types/survey"
+
+function field(overrides: Partial<SurveyField> = {}): SurveyField {
+  return { id: "f1", type: "string", label: "Champ", ...overrides }
+}
+
+describe("required", () => {
+  it("returns error when required field is empty string", () => {
+    expect(validateField(field({ required: true }), "")).not.toBeNull()
+  })
+
+  it("returns error when required field is null", () => {
+    expect(validateField(field({ required: true }), null)).not.toBeNull()
+  })
+
+  it("returns error when required field is empty array", () => {
+    expect(validateField(field({ required: true }), [])).not.toBeNull()
+  })
+
+  it("returns null when required field has a value", () => {
+    expect(validateField(field({ required: true }), "hello")).toBeNull()
+  })
+
+  it("returns null when non-required field is empty", () => {
+    expect(validateField(field({ required: false }), "")).toBeNull()
+  })
+})
+
+describe("number widget", () => {
+  const num = (validation: SurveyField["validation"] = {}) =>
+    field({ ui: { widget: "number" }, validation })
+
+  it("accepts a valid integer when numberType is integer", () => {
+    expect(validateField(num({ numberType: "integer" }), 3)).toBeNull()
+  })
+
+  it("rejects a float when numberType is integer", () => {
+    expect(validateField(num({ numberType: "integer" }), 3.5)).not.toBeNull()
+  })
+
+  it("accepts a float when numberType is float", () => {
+    expect(validateField(num({ numberType: "float" }), 3.14)).toBeNull()
+  })
+
+  it("rejects a non-numeric string", () => {
+    expect(validateField(num(), "abc")).not.toBeNull()
+  })
+
+  it("rejects a value below min", () => {
+    expect(validateField(num({ min: 5 }), 3)).not.toBeNull()
+  })
+
+  it("accepts a value equal to min", () => {
+    expect(validateField(num({ min: 5 }), 5)).toBeNull()
+  })
+
+  it("rejects a value above max", () => {
+    expect(validateField(num({ max: 10 }), 12)).not.toBeNull()
+  })
+
+  it("accepts a value equal to max", () => {
+    expect(validateField(num({ max: 10 }), 10)).toBeNull()
+  })
+
+  it("accepts a value within [min, max]", () => {
+    expect(validateField(num({ min: 1, max: 100 }), 50)).toBeNull()
+  })
+
+  it("returns null for empty value even with constraints (not required)", () => {
+    expect(
+      validateField(num({ min: 1, numberType: "integer" }), null)
+    ).toBeNull()
+  })
+})
+
+describe("date widget", () => {
+  const dateField = (validation: SurveyField["validation"] = {}) =>
+    field({ ui: { widget: "date" }, validation })
+
+  it("rejects a date before min", () => {
+    expect(
+      validateField(dateField({ min: "2024-01-01" }), "2023-06-15")
+    ).not.toBeNull()
+  })
+
+  it("accepts a date equal to min", () => {
+    expect(
+      validateField(dateField({ min: "2024-01-01" }), "2024-01-01")
+    ).toBeNull()
+  })
+
+  it("rejects a date after max", () => {
+    expect(
+      validateField(dateField({ max: "2024-12-31" }), "2025-03-01")
+    ).not.toBeNull()
+  })
+
+  it("accepts a date equal to max", () => {
+    expect(
+      validateField(dateField({ max: "2024-12-31" }), "2024-12-31")
+    ).toBeNull()
+  })
+
+  it("accepts a date within [min, max]", () => {
+    expect(
+      validateField(
+        dateField({ min: "2024-01-01", max: "2024-12-31" }),
+        "2024-06-15"
+      )
+    ).toBeNull()
+  })
+})
+
+describe("string widget", () => {
+  const str = (
+    widget: "input" | "autocomplete",
+    validation: SurveyField["validation"] = {}
+  ) => field({ ui: { widget }, validation })
+
+  it.each(["input", "autocomplete"] as const)(
+    "%s: rejects value shorter than minLength",
+    (widget) => {
+      expect(validateField(str(widget, { minLength: 5 }), "hi")).not.toBeNull()
+    }
+  )
+
+  it.each(["input", "autocomplete"] as const)(
+    "%s: accepts value equal to minLength",
+    (widget) => {
+      expect(validateField(str(widget, { minLength: 3 }), "abc")).toBeNull()
+    }
+  )
+
+  it.each(["input", "autocomplete"] as const)(
+    "%s: rejects value longer than maxLength",
+    (widget) => {
+      expect(
+        validateField(str(widget, { maxLength: 3 }), "toolong")
+      ).not.toBeNull()
+    }
+  )
+
+  it.each(["input", "autocomplete"] as const)(
+    "%s: accepts value equal to maxLength",
+    (widget) => {
+      expect(validateField(str(widget, { maxLength: 5 }), "hello")).toBeNull()
+    }
+  )
+})
+
+describe("array-like widgets", () => {
+  const arr = (
+    widget: "array" | "checkboxes" | "image",
+    validation: SurveyField["validation"] = {}
+  ) => field({ ui: { widget }, validation })
+
+  it.each(["array", "checkboxes", "image"] as const)(
+    "%s: rejects fewer items than minItems",
+    (widget) => {
+      expect(validateField(arr(widget, { minItems: 2 }), ["a"])).not.toBeNull()
+    }
+  )
+
+  it.each(["array", "checkboxes", "image"] as const)(
+    "%s: accepts count equal to minItems",
+    (widget) => {
+      expect(validateField(arr(widget, { minItems: 2 }), ["a", "b"])).toBeNull()
+    }
+  )
+
+  it.each(["array", "checkboxes", "image"] as const)(
+    "%s: rejects more items than maxItems",
+    (widget) => {
+      expect(
+        validateField(arr(widget, { maxItems: 2 }), ["a", "b", "c"])
+      ).not.toBeNull()
+    }
+  )
+
+  it.each(["array", "checkboxes", "image"] as const)(
+    "%s: accepts count equal to maxItems",
+    (widget) => {
+      expect(
+        validateField(arr(widget, { maxItems: 3 }), ["a", "b", "c"])
+      ).toBeNull()
+    }
+  )
+})
+
+describe("validateResponse", () => {
+  const schema: SurveyField[] = [
+    field({
+      id: "age",
+      ui: { widget: "number" },
+      validation: { numberType: "integer" },
+    }),
+    field({ id: "name", ui: { widget: "input" }, required: true }),
+    field({
+      id: "note",
+      ui: { widget: "input" },
+      validation: { maxLength: 5 },
+    }),
+  ]
+
+  it("returns empty object when all fields are valid", () => {
+    const errors = validateResponse(schema, {
+      age: 25,
+      name: "Alice",
+      note: "ok",
+    })
+    expect(errors).toEqual({})
+  })
+
+  it("returns errors for each invalid field", () => {
+    const errors = validateResponse(schema, {
+      age: 1.5,
+      name: "",
+      note: "toolongvalue",
+    })
+    expect(errors).toHaveProperty("age")
+    expect(errors).toHaveProperty("name")
+    expect(errors).toHaveProperty("note")
+  })
+
+  it("omits fields not in visibleFieldIds", () => {
+    const errors = validateResponse(
+      schema,
+      { age: 1.5, name: "", note: "" },
+      new Set(["name"])
+    )
+    expect(errors).not.toHaveProperty("age")
+    expect(errors).toHaveProperty("name")
+  })
+
+  it("returns only failing fields, not passing ones", () => {
+    const errors = validateResponse(schema, { age: 5, name: "", note: "hi" })
+    expect(errors).not.toHaveProperty("age")
+    expect(errors).toHaveProperty("name")
+    expect(errors).not.toHaveProperty("note")
+  })
+})

--- a/shared/components/AutocompleteField.vue
+++ b/shared/components/AutocompleteField.vue
@@ -9,6 +9,7 @@ const props = defineProps<{
   disabled?: boolean
   hint?: string
   placeholder?: string
+  errorMessage?: string
 }>()
 
 const modelValue = defineModel<string>()
@@ -103,7 +104,7 @@ const onKeydown = (e: KeyboardEvent) => {
 </script>
 
 <template>
-  <DsfrInputGroup>
+  <DsfrInputGroup :class="errorMessage ? 'fr-input-group--error' : ''">
     <div class="relative">
       <div class="flex items-end">
         <div class="grow">
@@ -151,5 +152,6 @@ const onKeydown = (e: KeyboardEvent) => {
         </li>
       </ul>
     </div>
+    <p v-if="errorMessage" class="fr-error-text">{{ errorMessage }}</p>
   </DsfrInputGroup>
 </template>

--- a/shared/components/FieldRenderer.vue
+++ b/shared/components/FieldRenderer.vue
@@ -11,10 +11,12 @@ import type {
 import ArrayField from "./ArrayField.vue"
 import AutocompleteField from "./AutocompleteField.vue"
 import ImagesField from "./ImagesField.vue"
+import { validateField } from "@shared-utils/validateField"
 
 const props = defineProps<{
   field: SurveyField
   disabled?: boolean
+  readonly?: boolean
   vocabularies?: VocabularySet[]
   mapComponent?: Component
 }>()
@@ -83,11 +85,15 @@ const mapValue = computed({
     modelValue.value = val
   },
 })
+
+const errorMessage = computed(() =>
+  props.readonly || props.disabled ? null : validateField(props.field, modelValue.value)
+)
 </script>
 
 <template>
   <div>
-    <DsfrInputGroup v-if="field.ui?.widget === 'input'">
+    <DsfrInputGroup v-if="field.ui?.widget === 'input'" :error-message="errorMessage ?? undefined">
       <!-- Champ texte -->
       <DsfrInput
         v-model="modelValue"
@@ -98,11 +104,12 @@ const mapValue = computed({
         :placeholder="field.ui?.placeholder"
         :isTextarea="field.ui?.textarea"
         :disabled="disabled"
+        :is-invalid="!!errorMessage"
       />
     </DsfrInputGroup>
 
     <!-- Champ numérique -->
-    <DsfrInputGroup v-else-if="field.ui?.widget === 'number'">
+    <DsfrInputGroup v-else-if="field.ui?.widget === 'number'" :error-message="errorMessage ?? undefined">
       <DsfrInput
         v-model="modelValue"
         :label="field.label"
@@ -115,6 +122,7 @@ const mapValue = computed({
         :max="field.validation?.max"
         :disabled="disabled"
         :step="field.validation?.numberType === 'integer' ? 1 : field.validation?.numberType === 'float' ? 'any' : undefined"
+        :is-invalid="!!errorMessage"
       />
     </DsfrInputGroup>
 
@@ -127,6 +135,7 @@ const mapValue = computed({
         v-model="modelValue"
         :disabled="disabled"
         :defaultUnselectedText="field.ui?.unselectedText"
+        :error-message="errorMessage ?? undefined"
       />
     </DsfrInputGroup>
 
@@ -138,6 +147,7 @@ const mapValue = computed({
         :required="field.required ?? false"
         v-model="modelValue"
         :disabled="disabled"
+        :error-message="errorMessage ?? undefined"
       />
     </DsfrInputGroup>
 
@@ -163,11 +173,12 @@ const mapValue = computed({
         :required="field.required ?? false"
         v-model="modelValue"
         :disabled="disabled"
+        :error-message="errorMessage ?? undefined"
       />
     </DsfrInputGroup>
 
     <!-- Champ date -->
-    <DsfrInputGroup v-else-if="field.ui?.widget === 'date'">
+    <DsfrInputGroup v-else-if="field.ui?.widget === 'date'" :error-message="errorMessage ?? undefined">
       <DsfrInput
         v-model="modelValue"
         :label="field.label"
@@ -178,6 +189,7 @@ const mapValue = computed({
         :min="field.validation?.min"
         :max="field.validation?.max"
         :disabled="disabled"
+        :is-invalid="!!errorMessage"
       />
     </DsfrInputGroup>
 
@@ -197,6 +209,7 @@ const mapValue = computed({
       :hint="field.ui?.hint"
       :disabled="disabled"
       :placeholder="field.ui?.placeholder"
+      :error-message="errorMessage ?? undefined"
       v-model="autocompleteValue"
     />
 

--- a/shared/components/FieldRenderer.vue
+++ b/shared/components/FieldRenderer.vue
@@ -16,7 +16,6 @@ import { validateField } from "@shared-utils/validateField"
 const props = defineProps<{
   field: SurveyField
   disabled?: boolean
-  readonly?: boolean
   forceValidate?: boolean
   vocabularies?: VocabularySet[]
   mapComponent?: Component
@@ -98,7 +97,7 @@ const onFocusOut = (e: FocusEvent) => {
 }
 
 const errorMessage = computed(() =>
-  touched.value && !props.readonly && !props.disabled
+  touched.value && !props.disabled
     ? validateField(props.field, modelValue.value)
     : null
 )

--- a/shared/components/FieldRenderer.vue
+++ b/shared/components/FieldRenderer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, useId } from "vue"
+import { computed, ref, useId, watchEffect } from "vue"
 import type { Component } from "vue"
 import type {
   SurveyField,
@@ -17,6 +17,7 @@ const props = defineProps<{
   field: SurveyField
   disabled?: boolean
   readonly?: boolean
+  forceValidate?: boolean
   vocabularies?: VocabularySet[]
   mapComponent?: Component
 }>()
@@ -88,6 +89,7 @@ const mapValue = computed({
 
 const rootRef = ref<HTMLElement | null>(null)
 const touched = ref(false)
+watchEffect(() => { if (props.forceValidate) touched.value = true })
 
 const onFocusOut = (e: FocusEvent) => {
   if (!rootRef.value?.contains(e.relatedTarget as Node)) {

--- a/shared/components/FieldRenderer.vue
+++ b/shared/components/FieldRenderer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, useId } from "vue"
+import { computed, ref, useId } from "vue"
 import type { Component } from "vue"
 import type {
   SurveyField,
@@ -86,13 +86,24 @@ const mapValue = computed({
   },
 })
 
+const rootRef = ref<HTMLElement | null>(null)
+const touched = ref(false)
+
+const onFocusOut = (e: FocusEvent) => {
+  if (!rootRef.value?.contains(e.relatedTarget as Node)) {
+    touched.value = true
+  }
+}
+
 const errorMessage = computed(() =>
-  props.readonly || props.disabled ? null : validateField(props.field, modelValue.value)
+  touched.value && !props.readonly && !props.disabled
+    ? validateField(props.field, modelValue.value)
+    : null
 )
 </script>
 
 <template>
-  <div>
+  <div ref="rootRef" @focusout="onFocusOut">
     <DsfrInputGroup v-if="field.ui?.widget === 'input'" :error-message="errorMessage ?? undefined">
       <!-- Champ texte -->
       <DsfrInput

--- a/shared/components/SurveyRenderer.vue
+++ b/shared/components/SurveyRenderer.vue
@@ -12,6 +12,7 @@ const props = withDefaults(
     allowSubmit?: boolean
     prefillData?: Record<string, unknown>
     readonly?: boolean
+    forceValidate?: boolean
     vocabularies?: VocabularySet[]
     mapComponent?: Component
   }>(),
@@ -112,6 +113,7 @@ watch(formData, (newData) => emit("change", { ...newData }), { deep: true })
           :field="field"
           v-model="formData[field.id]"
           :disabled="readonly"
+          :force-validate="forceValidate"
           :vocabularies="props.vocabularies"
           :mapComponent="mapComponent"
         />

--- a/shared/utils/survey.ts
+++ b/shared/utils/survey.ts
@@ -36,15 +36,16 @@ export const resolveFieldValue = (
     return ""
   }
 
-  if (
-    field?.ui?.widget === "map" &&
-    typeof raw === "object" &&
-    raw !== null &&
-    "lat" in raw &&
-    "lon" in raw
-  ) {
-    const { lat, lon } = raw as { lat: number; lon: number }
-    return `Latitude : ${lat}, longitude : ${lon}`
+  if (field?.ui?.widget === "map") {
+    if (
+      typeof raw === "object" &&
+      raw !== null &&
+      "lat" in raw &&
+      "lon" in raw
+    ) {
+      const { lat, lon } = raw as { lat: number; lon: number }
+      return `Latitude : ${lat}, longitude : ${lon}`
+    } else return ""
   }
 
   if (field?.vocabulary) {

--- a/shared/utils/validateField.ts
+++ b/shared/utils/validateField.ts
@@ -90,7 +90,8 @@ export function validateResponse(
     if (field.fields && Array.isArray(data[field.id])) {
       const items = data[field.id] as Record<string, unknown>[]
       for (const item of items) {
-        for (const subField of field.fields) {
+        const subFields: SurveyField[] = field.fields!
+        for (const subField of subFields) {
           const subError = validateField(subField, item[subField.id] ?? null)
           if (subError) {
             const key = `${field.id}.${subField.id}`

--- a/shared/utils/validateField.ts
+++ b/shared/utils/validateField.ts
@@ -1,0 +1,123 @@
+import type { SurveyField } from "../types/survey"
+
+/**
+ * Validation d'un champ considérant les règles dans "validation"
+ * null si tout est OK, sinon message d'erreur
+ */
+export function validateField(
+  field: SurveyField,
+  value: unknown
+): string | null {
+  const v = field.validation
+
+  if (field.required) {
+    if (isEmpty(value)) return "Ce champ est obligatoire"
+  }
+
+  // Rien d'autre à valider si le champ est vide
+  if (isEmpty(value)) return null
+
+  const widget = field.ui?.widget
+
+  // Number
+  if (widget === "number") {
+    const num = Number(value)
+
+    if (isNaN(num)) return "La valeur doit être un nombre"
+
+    if (v?.numberType === "integer" && !Number.isInteger(num))
+      return "La valeur doit être un nombre entier"
+
+    if (v?.min !== undefined && num < Number(v.min))
+      return `La valeur doit être supérieure ou égale à ${v.min}`
+
+    if (v?.max !== undefined && num > Number(v.max))
+      return `La valeur doit être inférieure ou égale à ${v.max}`
+  }
+
+  // Date
+  if (widget === "date" && typeof value === "string") {
+    if (v?.min !== undefined && value < String(v.min))
+      return `La date doit être après le ${formatDate(String(v.min))}`
+
+    if (v?.max !== undefined && value > String(v.max))
+      return `La date doit être avant le ${formatDate(String(v.max))}`
+  }
+
+  // String
+  if (
+    (widget === "input" || widget === "autocomplete") &&
+    typeof value === "string"
+  ) {
+    if (v?.minLength !== undefined && value.length < v.minLength)
+      return `La valeur doit contenir au moins ${v.minLength} caractère(s)`
+
+    if (v?.maxLength !== undefined && value.length > v.maxLength)
+      return `La valeur doit contenir au plus ${v.maxLength} caractère(s)`
+  }
+
+  // Array
+  if (widget === "array" || widget === "checkboxes" || widget === "image") {
+    const arr = Array.isArray(value) ? value : []
+
+    if (v?.minItems !== undefined && arr.length < v.minItems)
+      return `Au moins ${v.minItems} élément(s) requis`
+
+    if (v?.maxItems !== undefined && arr.length > v.maxItems)
+      return `Au plus ${v.maxItems} élément(s) autorisés`
+  }
+
+  return null
+}
+
+/**
+ * Execute la validation sur chaque champ. Prend en compte seulement
+ * les champs visibles.
+ */
+export function validateResponse(
+  fields: SurveyField[],
+  data: Record<string, unknown>,
+  visibleFieldIds?: Set<string>
+): Record<string, string> {
+  const errors: Record<string, string> = {}
+
+  for (const field of fields) {
+    if (visibleFieldIds && !visibleFieldIds.has(field.id)) continue
+
+    const error = validateField(field, data[field.id] ?? null)
+    if (error) errors[field.id] = error
+
+    if (field.fields && Array.isArray(data[field.id])) {
+      const items = data[field.id] as Record<string, unknown>[]
+      for (const item of items) {
+        for (const subField of field.fields) {
+          const subError = validateField(subField, item[subField.id] ?? null)
+          if (subError) {
+            const key = `${field.id}.${subField.id}`
+            if (!errors[key]) errors[key] = subError
+          }
+        }
+      }
+    }
+  }
+
+  return errors
+}
+
+function isEmpty(value: unknown): boolean {
+  if (value === null || value === undefined || value === "") return true
+  if (Array.isArray(value) && value.length === 0) return true
+  return false
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString("fr-FR", {
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+    })
+  } catch {
+    return iso
+  }
+}


### PR DESCRIPTION
Cette PR concerne la validation fron-end à deux niveaux : 
- FormRenderer
- SurveySummary


Elle contient également certains fixes :
- "Non renseigné" est affiché lors que l'utilisateur ne remplit pas les coordonnées au lieu de "null"
- :lady_beetle: Boucle infinie de requête d'authentification si la requête d'auth échouait