### PR TITLE
Features et bug fixes pour les vocabulaires

### DIFF
--- a/backend/surveys/tests/test_vocabulary_set.py
+++ b/backend/surveys/tests/test_vocabulary_set.py
@@ -1,7 +1,7 @@
 from django.urls import reverse
 
 from common.utils import authenticate
-from organisations.factories import MembershipFactory, OrganisationFactory
+from organisations.factories import MembershipFactory, OrganisationFactory, PoleFactory
 from organisations.models import MembershipType
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -177,6 +177,26 @@ class TestMobileVocabularySetList(APITestCase):
         """
         org = OrganisationFactory()
         MembershipFactory(user=authenticate.user, organisation=org, membership_type=MembershipType.RESPONDER)
+        vocab = VocabularySetFactory(organisation=None)
+        SurveyFactory(organisation=org, json_schema=self._schema_with_vocabulary(vocab.code))
+
+        response = self.client.get(reverse("mobile_vocabulary_set_list"), format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        codes = [v["code"] for v in response.json()]
+        self.assertIn(vocab.code, codes)
+
+    @authenticate
+    def test_returns_vocabularies_referenced_in_user_pole_role_surveys(self):
+        """
+        Un·e utilisateur·ice ayant un rôle de réponse pour un pôle peut voir les vocabulaires
+        référencés dans les enquêtes sans pôle
+        """
+        pole = PoleFactory()
+        org = pole.organisation
+        MembershipFactory(
+            user=authenticate.user, organisation=org, pole=pole, membership_type=MembershipType.RESPONDER
+        )
         vocab = VocabularySetFactory(organisation=None)
         SurveyFactory(organisation=org, json_schema=self._schema_with_vocabulary(vocab.code))
 

--- a/backend/surveys/views/survey.py
+++ b/backend/surveys/views/survey.py
@@ -42,6 +42,29 @@ class SurveyListCreateAPIView(SurveyQuerySetMixin, ListCreateAPIView):
         serializer.save(created_by=self.request.user)
 
 
+def _responder_survey_queryset(user):
+    """Enquêtes auxquelles user peut répondre (rôle RESPONDER uniquement).
+    Les RESPONDER rattachés à un pôle voient aussi les enquêtes sans pôle de la même organisation."""
+    org_ids = Membership.objects.filter(
+        user=user, membership_type=MembershipType.RESPONDER, pole__isnull=True
+    ).values_list("organisation_id", flat=True)
+
+    pole_memberships = list(
+        Membership.objects.filter(user=user, membership_type=MembershipType.RESPONDER, pole__isnull=False).values(
+            "pole_id", "organisation_id"
+        )
+    )
+
+    pole_ids = [m["pole_id"] for m in pole_memberships]
+    pole_org_ids = [m["organisation_id"] for m in pole_memberships]
+
+    return Survey.objects.filter(
+        Q(organisation_id__in=org_ids)
+        | Q(pole_id__in=pole_ids)
+        | Q(organisation_id__in=pole_org_ids, pole__isnull=True)
+    ).distinct()
+
+
 class SurveyResponderListAPIView(ListAPIView):
     """
     Retourne seulement les enquêtes auxquelles l'utilisateur·ice connecté·e peut répondre.
@@ -52,26 +75,7 @@ class SurveyResponderListAPIView(ListAPIView):
     permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
-        user = self.request.user
-
-        org_ids = Membership.objects.filter(
-            user=user, membership_type=MembershipType.RESPONDER, pole__isnull=True
-        ).values_list("organisation_id", flat=True)
-
-        pole_memberships = list(
-            Membership.objects.filter(user=user, membership_type=MembershipType.RESPONDER, pole__isnull=False).values(
-                "pole_id", "organisation_id"
-            )
-        )
-
-        pole_ids = [m["pole_id"] for m in pole_memberships]
-        pole_org_ids = [m["organisation_id"] for m in pole_memberships]
-
-        return Survey.objects.filter(
-            Q(organisation_id__in=org_ids)
-            | Q(pole_id__in=pole_ids)
-            | Q(organisation_id__in=pole_org_ids, pole__isnull=True)
-        ).distinct()
+        return _responder_survey_queryset(self.request.user)
 
 
 class SurveyRetrieveAPIView(SurveyQuerySetMixin, RetrieveAPIView):

--- a/backend/surveys/views/vocabularyset.py
+++ b/backend/surveys/views/vocabularyset.py
@@ -1,11 +1,11 @@
 from django.db.models import Prefetch, Q
 
-from organisations.models import Membership, MembershipType
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.permissions import IsAuthenticated
 
-from surveys.models import Survey, VocabularyEntry, VocabularySet
+from surveys.models import VocabularyEntry, VocabularySet
 from surveys.serializers import VocabularySetDisplaySerializer, VocabularySetSerializer
+from surveys.views.survey import _responder_survey_queryset
 
 
 def _active_entries_prefetch():
@@ -54,14 +54,7 @@ class MobileVocabularySetListView(ListAPIView):
     def get_queryset(self):
         user = self.request.user
 
-        org_ids = Membership.objects.filter(
-            user=user, membership_type=MembershipType.RESPONDER, pole__isnull=True
-        ).values_list("organisation_id", flat=True)
-        pole_ids = Membership.objects.filter(
-            user=user, membership_type=MembershipType.RESPONDER, pole__isnull=False
-        ).values_list("pole_id", flat=True)
-
-        surveys = Survey.objects.filter(Q(organisation_id__in=org_ids) | Q(pole_id__in=pole_ids)).only("json_schema")
+        surveys = _responder_survey_queryset(user).only("json_schema")
 
         vocabulary_codes = set()
         for survey in surveys:

--- a/mobile/src/pages/ResponseListPage/index.vue
+++ b/mobile/src/pages/ResponseListPage/index.vue
@@ -12,6 +12,7 @@ import {
 } from "@ionic/vue"
 import { useResponsesStore } from "../../stores/responses"
 import { useSurveysStore } from "../../stores/surveys"
+import { useVocabulariesStore } from "../../stores/vocabularies.ts"
 import ResponseCard from "./ResponseCard.vue"
 import SurveyPage from "../SurveyPage.vue"
 import { computed, ref } from "vue"
@@ -19,6 +20,7 @@ import type { ResponseFull, LocalResponse } from "@shared-types/response"
 
 const responsesStore = useResponsesStore()
 const surveysStore = useSurveysStore()
+const vocabulariesStore = useVocabulariesStore()
 
 const byDateDesc = (
   a: LocalResponse | ResponseFull,
@@ -56,6 +58,7 @@ const onOpen = (response: LocalResponse | ResponseFull) => {
 const handleRefresh = async (event: CustomEvent) => {
   await surveysStore.sync()
   await responsesStore.sync()
+  await vocabulariesStore.sync()
   ;(event.target as HTMLIonRefresherElement).complete()
 }
 

--- a/shared/components/AutocompleteField.vue
+++ b/shared/components/AutocompleteField.vue
@@ -17,6 +17,18 @@ const query = ref("")
 const isOpen = ref(false)
 const highlightedIndex = ref(-1)
 const listRef = ref<HTMLUListElement | null>(null)
+const containerRef = ref<HTMLElement | null>(null)
+const dropdownStyle = ref({ top: "0px", left: "0px", width: "0px" })
+
+const updateDropdownPosition = () => {
+  const rect = containerRef.value?.getBoundingClientRect()
+  if (!rect) return
+  dropdownStyle.value = {
+    top: `${rect.bottom}px`,
+    left: `${rect.left}px`,
+    width: `${rect.width}px`,
+  }
+}
 
 const normalize = (s: string) =>
   s
@@ -54,6 +66,7 @@ if (modelValue.value) {
 const onFocus = () => {
   query.value = selectedLabel.value
   isOpen.value = true
+  updateDropdownPosition()
 }
 
 // @mousedown.prevent dans la liste maintient le focus dans l'input, blur n'est
@@ -104,7 +117,7 @@ const onKeydown = (e: KeyboardEvent) => {
 
 <template>
   <DsfrInputGroup>
-    <div class="relative">
+    <div ref="containerRef" class="relative">
       <div class="flex items-end">
         <div class="grow">
           <DsfrInput
@@ -129,27 +142,31 @@ const onKeydown = (e: KeyboardEvent) => {
         </div>
         <v-icon icon="ri-search-line" class="mb-3 mx-2" />
       </div>
-      <ul
-        v-if="isOpen && filtered.length"
-        ref="listRef"
-        class="absolute z-50 bg-white border border-slate-200 rounded shadow-md max-h-60 overflow-y-auto w-full pl-0!"
-        role="listbox"
-      >
-        <li
-          v-for="(entry, i) in filtered"
-          :key="entry.code"
-          class="px-4 pt-4! pb-4! cursor-pointer fr-text--sm mb-0! list-none"
-          :class="i === highlightedIndex ? 'bg-blue-50' : 'hover:bg-slate-100'"
-          role="option"
-          :aria-selected="i === highlightedIndex"
-          @mousedown.prevent="select(entry)"
-        >
-          <span class="font-medium">{{ entry.label }}</span>
-          <span class="text-gray-400 ml-2 font-mono text-xs">{{
-            entry.code
-          }}</span>
-        </li>
-      </ul>
     </div>
   </DsfrInputGroup>
+
+  <Teleport to="body">
+    <ul
+      v-if="isOpen && filtered.length"
+      ref="listRef"
+      :style="dropdownStyle"
+      class="fixed z-[9999] bg-white border border-slate-200 rounded shadow-md max-h-60 overflow-y-auto pl-0!"
+      role="listbox"
+    >
+      <li
+        v-for="(entry, i) in filtered"
+        :key="entry.code"
+        class="px-4 pt-4! pb-4! cursor-pointer fr-text--sm mb-0! list-none"
+        :class="i === highlightedIndex ? 'bg-blue-50' : 'hover:bg-slate-100'"
+        role="option"
+        :aria-selected="i === highlightedIndex"
+        @mousedown.prevent="select(entry)"
+      >
+        <span class="font-medium">{{ entry.label }}</span>
+        <span class="text-gray-400 ml-2 font-mono text-xs">{{
+          entry.code
+        }}</span>
+      </li>
+    </ul>
+  </Teleport>
 </template>

--- a/web/src/components/SurveyBuilder/NewFieldModal.vue
+++ b/web/src/components/SurveyBuilder/NewFieldModal.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, nextTick } from "vue"
-import type { SurveyField, FieldWidget, FieldType } from "@shared-types/survey"
+import type { SurveyField, FieldWidget, FieldType, VocabularyEntry } from "@shared-types/survey"
+import AutocompleteField from "@shared-components/AutocompleteField.vue"
 import ConditionModalSegment from "./ConditionModalSegment.vue"
 import * as z from "zod"
 import { ZodError } from "zod"
@@ -62,6 +63,23 @@ const vocabularySelectOptions = computed(() =>
     value: v.code,
   }))
 )
+
+const useVocabularyAutocomplete = computed(
+  () => (vocabularySelectOptions.value?.length ?? 0) > 20
+)
+
+const vocabularyAutocompleteEntries = computed((): VocabularyEntry[] =>
+  rootStore.vocabularies?.map((v) => ({
+    code: v.code,
+    label: `${v.code} — ${v.name}`,
+    position: null,
+  })) ?? []
+)
+
+const vocabularyCodeModel = computed({
+  get: () => selectedVocabularyCode.value,
+  set: (code: string) => onVocabularyChange(code),
+})
 
 const resolvedVocabulary = computed(() =>
   selectedVocabularyCode.value
@@ -371,7 +389,15 @@ const close = () => {
         v-if="optionsSource === 'vocabulary'"
         class="flex items-center gap-2"
       >
+        <AutocompleteField
+          v-if="useVocabularyAutocomplete"
+          class="max-w-lg grow"
+          label="Référentiel"
+          :entries="vocabularyAutocompleteEntries"
+          v-model="vocabularyCodeModel"
+        />
         <DsfrSelect
+          v-else
           class="max-w-lg grow"
           label="Référentiel"
           :options="vocabularySelectOptions"
@@ -423,7 +449,15 @@ const close = () => {
         v-if="optionsSource === 'vocabulary'"
         class="flex items-center gap-2"
       >
+        <AutocompleteField
+          v-if="useVocabularyAutocomplete"
+          class="max-w-lg grow"
+          label="Référentiel"
+          :entries="vocabularyAutocompleteEntries"
+          v-model="vocabularyCodeModel"
+        />
         <DsfrSelect
+          v-else
           class="max-w-lg grow"
           label="Référentiel"
           :options="vocabularySelectOptions"
@@ -509,7 +543,15 @@ const close = () => {
         v-if="optionsSource === 'vocabulary'"
         class="flex items-center gap-2"
       >
+        <AutocompleteField
+          v-if="useVocabularyAutocomplete"
+          class="max-w-lg grow"
+          label="Référentiel"
+          :entries="vocabularyAutocompleteEntries"
+          v-model="vocabularyCodeModel"
+        />
         <DsfrSelect
+          v-else
           class="max-w-lg grow"
           label="Référentiel"
           :options="vocabularySelectOptions"


### PR DESCRIPTION
PR regroupant trois fonctionnalités :

- :lady_beetle: Bug fix où un utilisateur·ice ayant un rôle _Responder_ et un scope d'un pôle ne voyait pas les vocabulaires des enquêtes sans pôle.
- Dans le créateur d'enquêtes, la liste déroulante utilisée pour choisir un référentiel devient un auto-complete lors que la liste de référentiels excède 20 éléments
- Le pull-down-to-refresh obtient les vocabulaires du serveur dans l'application mobile