### PR TITLE
Simplification de la UI pour la carte

### DIFF
--- a/mobile/src/components/MapDownloader.vue
+++ b/mobile/src/components/MapDownloader.vue
@@ -125,9 +125,6 @@ async function confirmSave() {
       <div class="flex flex-col gap-1 text-sm">
         <span>{{ progress.downloaded }} / {{ progress.total }} tuiles</span>
         <span>{{ mbDownloaded }} Mo téléchargés</span>
-        <span v-if="progress.failed > 0" class="failed">
-          ⚠ {{ progress.failed }} erreurs (nouvelle tentative automatique)
-        </span>
       </div>
 
       <DsfrButton
@@ -221,9 +218,5 @@ async function confirmSave() {
   height: 6px;
   border-radius: 3px;
   margin-bottom: 0.75rem;
-}
-
-.failed {
-  color: var(--warning-425-625, #b34000);
 }
 </style>

--- a/mobile/src/components/MapDownloader.vue
+++ b/mobile/src/components/MapDownloader.vue
@@ -30,14 +30,6 @@ const estimate = computed(() =>
 )
 const estimateMb = computed(() => (estimate.value.bytes / 1_000_000).toFixed(1))
 
-const etaLabel = computed(() => {
-  const s = progress.value.etaSeconds
-  if (s <= 0) return "…"
-  const m = Math.floor(s / 60)
-  const sec = s % 60
-  return m > 0 ? `${m}min ${sec}s` : `${sec}s`
-})
-
 const mbDownloaded = computed(() =>
   (progress.value.bytesStored / 1_000_000).toFixed(1)
 )
@@ -122,7 +114,6 @@ async function confirmSave() {
         <span class="text-3xl font-bold leading-none" style="color: #000091">
           {{ progress.percent }}&thinsp;%
         </span>
-        <span class="text-sm text-stone-500">ETA&nbsp;: {{ etaLabel }}</span>
       </div>
 
       <ion-progress-bar

--- a/mobile/src/composables/useOfflineMap.ts
+++ b/mobile/src/composables/useOfflineMap.ts
@@ -184,7 +184,6 @@ export const useOfflineMap = () => {
     total: 0,
     failed: 0,
     bytesStored: 0,
-    etaSeconds: 0,
     percent: 0,
   })
   const errorMessage = ref<string | null>(null)
@@ -223,7 +222,6 @@ export const useOfflineMap = () => {
       total: allTiles.length,
       failed: 0,
       bytesStored: 0,
-      etaSeconds: 0,
       percent: Math.round(
         ((allTiles.length - pendingTiles.length) / allTiles.length) * 100
       ),
@@ -251,11 +249,6 @@ export const useOfflineMap = () => {
           progress.value.downloaded++
           progress.value.bytesStored += buffer.byteLength
 
-          const elapsed = (Date.now() - startTime) / 1000
-          const rate = completedSinceStart / elapsed
-          const remaining = pendingTiles.length - completedSinceStart
-          progress.value.etaSeconds =
-            rate > 0 ? Math.round(remaining / rate) : 0
           progress.value.percent = Math.round(
             (progress.value.downloaded / progress.value.total) * 100
           )
@@ -305,7 +298,6 @@ export const useOfflineMap = () => {
       total: 0,
       failed: 0,
       bytesStored: 0,
-      etaSeconds: 0,
       percent: 0,
     }
   }

--- a/mobile/src/composables/useOfflineMap.ts
+++ b/mobile/src/composables/useOfflineMap.ts
@@ -227,7 +227,6 @@ export const useOfflineMap = () => {
       ),
     }
 
-    const startTime = Date.now()
     let completedSinceStart = 0
 
     // On ne traite qu'un numéro limité de tuiles

--- a/mobile/src/pages/MapDownloadPage.vue
+++ b/mobile/src/pages/MapDownloadPage.vue
@@ -6,9 +6,12 @@ import {
   IonHeader,
   IonToolbar,
   IonButtons,
+  IonButton,
+  IonIcon,
   IonMenuButton,
   IonTitle,
 } from "@ionic/vue"
+import { closeOutline } from "ionicons/icons"
 import maplibregl from "maplibre-gl"
 import "maplibre-gl/dist/maplibre-gl.css"
 import MapDownloader from "../components/MapDownloader.vue"
@@ -105,6 +108,11 @@ onBeforeUnmount(() => {
         <ion-title>Téléchargez une zone</ion-title>
         <ion-buttons slot="start">
           <ion-menu-button />
+        </ion-buttons>
+        <ion-buttons slot="end">
+          <ion-button @click="router.back()">
+            <ion-icon slot="icon-only" :icon="closeOutline" />
+          </ion-button>
         </ion-buttons>
       </ion-toolbar>
     </ion-header>

--- a/shared/types/maps.d.ts
+++ b/shared/types/maps.d.ts
@@ -20,7 +20,6 @@ export interface DownloadProgress {
   total: number
   failed: number
   bytesStored: number
-  etaSeconds: number
   percent: number
 }
 


### PR DESCRIPTION
- Enlève le label ETA
- Enlève le message d'erreur pour les erreurs qui se relancent automatiquement
- Permet la fermeture de la page pour revenir en arrière 