### PR TITLE
Fix du bug concernant le sous-champ géoloc

### DIFF
--- a/shared/components/ArrayField.vue
+++ b/shared/components/ArrayField.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { watch } from "vue"
+import type { Component } from "vue"
 import type { SurveyField, VocabularySet } from "../types/survey"
 import FieldRenderer from "./FieldRenderer.vue"
 import { getEmptyValue, evaluateCondition } from "../utils/survey"
@@ -14,6 +15,7 @@ const props = defineProps<{
   disabled?: boolean
   forceValidate?: boolean
   vocabularies?: VocabularySet[]
+  mapComponent?: Component
 }>()
 
 const modelValue = defineModel<Record<string, unknown>[]>({ default: () => [] })
@@ -106,6 +108,7 @@ watch(
           :disabled="disabled"
           :force-validate="forceValidate"
           :vocabularies="props.vocabularies"
+          :map-component="props.mapComponent"
           @update:model-value="updateItem(index, subField.id, $event)"
         />
       </template>

--- a/shared/components/FieldRenderer.vue
+++ b/shared/components/FieldRenderer.vue
@@ -212,6 +212,7 @@ const errorMessage = computed(() =>
       :disabled="disabled"
       :force-validate="forceValidate"
       :vocabularies="props.vocabularies"
+      :map-component="mapComponent"
     />
 
     <AutocompleteField


### PR DESCRIPTION
Lors qu'on utilisait un sous-champ type carte, le sous-champ ne s'affichait pas. Cette PR contient le fix : 

<img width="257" height="535" alt="image" src="https://github.com/user-attachments/assets/5164f59b-56be-4064-9541-6fc2fa6eac09" />
