### PR TITLE
Mise à jour des données et gestion des requêtes en cours dans les boutons

### DIFF
--- a/mobile/scripts/icons.js
+++ b/mobile/scripts/icons.js
@@ -34,6 +34,7 @@ export const collectionsToFilter = [
       "refresh-line",
       "save-line",
       "zoom-in-line",
+      "logout-box-r-line",
     ],
   ],
 ]

--- a/mobile/src/pages/LoginPage.vue
+++ b/mobile/src/pages/LoginPage.vue
@@ -20,6 +20,7 @@ const validator = z.object({
 })
 
 const formErrors = ref<any>()
+const loading = ref(false)
 
 const resetFields = () => {
   payload.value.username = ""
@@ -30,11 +31,14 @@ const resetFields = () => {
 const submit = async () => {
   try {
     const validatedData = validator.parse(payload.value)
+    loading.value = true
     await authStore.login(validatedData.username, validatedData.password)
     router.push({ name: "PositionPage" })
     resetFields()
   } catch (error) {
     if (error instanceof ZodError) formErrors.value = z.flattenError(error)
+  } finally {
+    loading.value = false
   }
 }
 
@@ -74,7 +78,12 @@ const loginWithDsf = async () => {
           </DsfrInputGroup>
 
           <div class="fr-mt-4w text-center">
-            <DsfrButton label="Se connecter" @click="submit" />
+            <DsfrButton
+              label="Se connecter"
+              :icon="loading ? { name: 'ri-refresh-line', animation: 'spin' } : undefined"
+              :disabled="loading"
+              @click="submit"
+            />
           </div>
 
           <div class="flex items-center gap-3 fr-mt-4w">

--- a/mobile/src/pages/ResponseListPage/index.vue
+++ b/mobile/src/pages/ResponseListPage/index.vue
@@ -134,6 +134,9 @@ ion-content,
 ion-content::part(background) {
   background: #f4f4ff;
 }
+ion-refresher {
+  --background: #f4f4ff;
+}
 ion-content {
   --padding-top: 0;
   --padding-bottom: 0;

--- a/mobile/src/pages/SettingsPage.vue
+++ b/mobile/src/pages/SettingsPage.vue
@@ -7,6 +7,7 @@ import {
   IonContent,
   IonTitle,
   IonIcon,
+  alertController,
 } from "@ionic/vue"
 import { computed, ref, onUnmounted } from "vue"
 import { useRouter } from "vue-router"
@@ -54,8 +55,22 @@ const fullName = computed(() => {
 })
 
 const logout = async () => {
-  await authStore.logout()
-  router.replace({ name: "LoginPage" })
+  const alert = await alertController.create({
+    header: "Se déconnecter ?",
+    message: "Vous devrez vous reconnecter pour accéder à l'application.",
+    buttons: [
+      { text: "Annuler", role: "cancel" },
+      {
+        text: "Se déconnecter",
+        role: "destructive",
+        handler: async () => {
+          await authStore.logout()
+          router.replace({ name: "LoginPage" })
+        },
+      },
+    ],
+  })
+  await alert.present()
 }
 </script>
 
@@ -67,26 +82,43 @@ const logout = async () => {
       </ion-toolbar>
     </ion-header>
     <ion-content class="ion-padding">
-      <section class="mb-4 flex items-center gap-3">
-        <div class="flex flex-col items-center gap-0">
-          <ion-icon
-            :icon="personOutline"
-            class="p-2 bg-slate-100 rounded-full border border-slate-300"
-          />
-          <p
-            v-if="loggedUser?.source !== 'local'"
-            class="mb-0! fr-text--xs font-medium text-emerald-700"
-          >
-            {{ `${loggedUser?.source?.toUpperCase()}` }}
-          </p>
+      <section class="flex">
+        <div class="mb-4 flex items-center gap-3 grow">
+          <div class="flex flex-col items-center gap-0">
+            <ion-icon
+              :icon="personOutline"
+              class="p-2 bg-slate-100 rounded-full border border-slate-300"
+            />
+            <p
+              v-if="loggedUser?.source !== 'local'"
+              class="mb-0! fr-text--xs font-medium text-emerald-700"
+            >
+              {{ `${loggedUser?.source?.toUpperCase()}` }}
+            </p>
+          </div>
+          <div>
+            <p class="font-bold mb-0!">
+              {{ fullName }}
+            </p>
+            <p class="fr-text--sm text-gray-500 font-bold mb-0!">
+              {{ loggedUser?.username ?? "-" }}
+            </p>
+          </div>
         </div>
         <div>
-          <p class="font-bold mb-0!">
-            {{ fullName }}
-          </p>
-          <p class="fr-text--sm text-gray-500 font-bold mb-0!">
-            {{ loggedUser?.username ?? "-" }}
-          </p>
+          <DsfrButton
+            size="sm"
+            icon-only
+            title="Se déconnecter"
+            label="Se déconnecter"
+            tertiary
+            @click="logout"
+            :icon="{
+              name: 'ri-logout-box-r-line',
+              fill: 'var(--error-425-625)',
+            }"
+            class="rounded-full"
+          />
         </div>
       </section>
 
@@ -140,8 +172,6 @@ const logout = async () => {
           </div>
         </div>
       </section>
-
-      <DsfrButton label="Se déconnecter" secondary @click="logout" />
     </ion-content>
   </ion-page>
 </template>

--- a/mobile/src/pages/SettingsPage.vue
+++ b/mobile/src/pages/SettingsPage.vue
@@ -34,7 +34,7 @@ const sync = async () => {
 const now = ref(Date.now())
 const ticker = setInterval(() => {
   now.value = Date.now()
-}, 60000)
+}, 30000)
 onUnmounted(() => clearInterval(ticker))
 
 const syncedAtLabel = computed(() => {
@@ -100,7 +100,11 @@ const logout = async () => {
           label="Synchroniser"
           size="sm"
           secondary
-          icon="ri-refresh-line"
+          :icon="
+            syncing
+              ? { name: 'ri-refresh-line', animation: 'spin' }
+              : 'ri-refresh-line'
+          "
           :disabled="syncing"
           @click="sync"
         />

--- a/mobile/src/pages/SurveyListPage/index.vue
+++ b/mobile/src/pages/SurveyListPage/index.vue
@@ -6,22 +6,65 @@ import {
   IonContent,
   IonTitle,
 } from "@ionic/vue"
+import { computed, ref, onUnmounted } from "vue"
 import { storeToRefs } from "pinia"
 import { useSurveysStore } from "../../stores/surveys"
+import { useSyncStore } from "../../stores/sync"
+import { timeAgo } from "@shared-utils/date"
 import SurveyCard from "./SurveyCard.vue"
 
 const emit = defineEmits<{ select: [id: number] }>()
 
 const surveysStore = useSurveysStore()
 const { surveys } = storeToRefs(surveysStore)
+
+const syncStore = useSyncStore()
+const { syncedAt, syncing } = storeToRefs(syncStore)
+
+const sync = async () => {
+  await syncStore.syncAll()
+}
+
+const now = ref(Date.now())
+const ticker = setInterval(() => {
+  now.value = Date.now()
+}, 60000)
+onUnmounted(() => clearInterval(ticker))
+
+const syncedAtLabel = computed(() => {
+  void now.value
+  return syncedAt.value ? timeAgo(syncedAt.value) : "Jamais synchronisé"
+})
 </script>
 
 <template>
   <ion-page>
     <ion-header>
-      <ion-toolbar><ion-title>Mes enquêtes</ion-title> </ion-toolbar>
+      <ion-toolbar
+        ><ion-title class="box-border!">Mes enquêtes</ion-title>
+      </ion-toolbar>
     </ion-header>
     <ion-content class="ion-padding">
+      <div>
+        <div class="flex items-center">
+          <p class="mb-0! grow fr-text--sm text-stone-600">
+            Dernière màj {{ syncedAtLabel }}
+          </p>
+          <DsfrButton
+            size="sm"
+            tertiary
+            label="Actualiser"
+            :icon="
+              syncing
+                ? { name: 'ri-refresh-line', animation: 'spin' }
+                : 'ri-refresh-line'
+            "
+            :disabled="syncing"
+            @click="sync"
+          />
+        </div>
+        <hr class="pb-2! mt-2!" />
+      </div>
       <div class="grid grid-cols-2 gap-2! text-left">
         <SurveyCard
           :survey="survey"

--- a/mobile/src/pages/SurveyPage.vue
+++ b/mobile/src/pages/SurveyPage.vue
@@ -235,19 +235,13 @@ const saveResponse = async (data: Record<string, unknown>) => {
               @click="showSummary = false"
             />
             <div class="flex items-center gap-3">
-              <div
-                v-if="saving"
-                class="flex items-center gap-2 text-sm text-stone-500"
-              >
-                <ion-spinner
-                  name="crescent"
-                  style="width: 1rem; height: 1rem"
-                />
-                <span>Envoi en cours...</span>
-              </div>
               <DsfrButton
                 label="Sauvegarder"
-                icon="ri-cloud-line"
+                :icon="
+                  saving
+                    ? { name: 'ri-refresh-line', animation: 'spin' }
+                    : 'ri-cloud-line'
+                "
                 :disabled="saving || summaryHasErrors"
                 @click="saveResponse(summaryData)"
               />

--- a/mobile/src/pages/SurveyPage.vue
+++ b/mobile/src/pages/SurveyPage.vue
@@ -15,7 +15,6 @@ import {
   IonBackButton,
   IonButton,
   IonIcon,
-  IonSpinner,
   IonTitle,
   useIonRouter,
   alertController,


### PR DESCRIPTION
Cette PR ajoute un retour d'état de chargement/sauvegarde pour plusieurs interactions :
- Bouton de connexion : désactivé + icône tournante pendant l'authentification
- Bouton d'enregistrement du questionnaire : désactivé + icône tournante pendant la soumission (remplace l'ancien spinner + texte intégré)
- Boutons de synchronisation (SurveyListPage, SettingsPage) : icône tournante pendant la synchronisation
- Déconnexion : déplacée vers un bouton uniquement composé d'une icône dans l'en-tête du profil, désormais accompagné d'une modale de confirmation
- CSS du rafraîchisseur : ajout de --background: #f4f4ff