### PR TITLE
Met la barre status à sa version 'light'

### DIFF
--- a/mobile/android/app/capacitor.build.gradle
+++ b/mobile/android/app/capacitor.build.gradle
@@ -15,6 +15,7 @@ dependencies {
     implementation project(':capacitor-geolocation')
     implementation project(':capacitor-network')
     implementation project(':capacitor-preferences')
+    implementation project(':capacitor-status-bar')
 
 }
 

--- a/mobile/android/capacitor.settings.gradle
+++ b/mobile/android/capacitor.settings.gradle
@@ -19,3 +19,6 @@ project(':capacitor-network').projectDir = new File('../node_modules/@capacitor/
 
 include ':capacitor-preferences'
 project(':capacitor-preferences').projectDir = new File('../node_modules/@capacitor/preferences/android')
+
+include ':capacitor-status-bar'
+project(':capacitor-status-bar').projectDir = new File('../node_modules/@capacitor/status-bar/android')

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -18,6 +18,7 @@
         "@capacitor/ios": "^8.4.0",
         "@capacitor/network": "^8.0.1",
         "@capacitor/preferences": "^8.0.1",
+        "@capacitor/status-bar": "^8.0.2",
         "@gouvfr/dsfr": "^1.14.4",
         "@gouvminint/vue-dsfr": "^8.17.0",
         "@ionic/vue": "^8.8.9",
@@ -287,6 +288,15 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/@capacitor/preferences/-/preferences-8.0.1.tgz",
       "integrity": "sha512-T6no3ebi79XJCk91U3Jp/liJUwgBdvHR+s6vhvPkPxSuch7z3zx5Rv1bdWM6sWruNx+pViuEGqZvbfCdyBvcHQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/status-bar": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/status-bar/-/status-bar-8.0.2.tgz",
+      "integrity": "sha512-WXs8YB8B9eEaPZz+bcdY6t2nForF1FLoj/JU0Dl9RRgQnddnS98FEEyDooQhaY7wivr000j4+SC1FyeJkrFO7A==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -25,6 +25,7 @@
     "@capacitor/ios": "^8.4.0",
     "@capacitor/network": "^8.0.1",
     "@capacitor/preferences": "^8.0.1",
+    "@capacitor/status-bar": "^8.0.2",
     "@gouvfr/dsfr": "^1.14.4",
     "@gouvminint/vue-dsfr": "^8.17.0",
     "@ionic/vue": "^8.8.9",

--- a/mobile/src/main.ts
+++ b/mobile/src/main.ts
@@ -1,3 +1,10 @@
+import { StatusBar, Style } from "@capacitor/status-bar"
+import { Capacitor } from "@capacitor/core"
+
+if (Capacitor.isNativePlatform()) {
+  StatusBar.setStyle({ style: Style.Light })
+}
+
 import { createApp } from "vue"
 import "./style.css"
 import App from "./App.vue"


### PR DESCRIPTION
Les icônes d'en haut sont désormais visibles

<img width="416" alt="image" src="https://github.com/user-attachments/assets/80108675-4926-4305-8e32-0fe6315c1f8b" />
